### PR TITLE
assert

### DIFF
--- a/pyiron_lammps/lammps.py
+++ b/pyiron_lammps/lammps.py
@@ -154,7 +154,8 @@ class Lammps(AtomisticGenericJob):
         Returns:
 
         """
-        assert (self.structure is not None)
+        if not (self.structure is not None):
+            raise AssertionError()
         snapshot = self.structure.copy()
         snapshot.cell = self.get("output/generic/cells")[iteration_step]
         snapshot.positions = self.get("output/generic/positions")[iteration_step]


### PR DESCRIPTION
It was discovered that some projects used assert to enforce interface constraints. However, assert is removed with compiling to optimised byte code (python -o producing *.pyo files). This caused various protections to be removed. The use of assert is also considered as general bad practice in OpenStack codebases.